### PR TITLE
allow running tests in docker

### DIFF
--- a/conf.coffee
+++ b/conf.coffee
@@ -10,7 +10,7 @@ exports.config =
     count: 1
     maxInstances: 10
     chromeOptions:
-      args: ['no-sandbox']
+      args: ['--headless', '--no-sandbox', '--window-size=1024,800', '--disable-gpu']
 
 
   framework: 'jasmine'

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "docker": "docker run --rm -it -u \"$(id -u):$(id -g)\" -v \"$(pwd):/work\" --net=host testx/chrome",
 
-    "pretest": "node_modules/.bin/webdriver-manager update",
+    "pretest": "webdriver-manager update",
     "test": "protractor conf.coffee",
 
     "preforeground": "sed -i \"s/\\['--headless', /\\[/\" conf.coffee",

--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
     "testx-standard-objects": "^0.1.1"
   },
   "scripts": {
+
     "docker": "docker run --rm -it -u \"$(id -u):$(id -g)\" -v \"$(pwd):/work\" --net=host testx/chrome",
+
 
     "pretest": "webdriver-manager update",
     "test": "protractor conf.coffee",
 
-    "preforeground": "sed -i \"s/\\['--headless', /\\[/\" conf.coffee",
-    "foreground": "npm run test",
-    "postforeground": "sed -i \"s/args: \\[/args: \\['--headless', /\" conf.coffee"
+    "displayed": "npm run test -- --capabilities.chromeOptions.args="
 
   },
   "testx": {

--- a/package.json
+++ b/package.json
@@ -12,15 +12,12 @@
     "testx-standard-objects": "^0.1.1"
   },
   "scripts": {
-
-    "docker": "docker run --rm -it -u \"$(id -u):$(id -g)\" -v \"$(pwd):/work\" --net=host testx/chrome",
-
-
     "pretest": "webdriver-manager update",
     "test": "protractor conf.coffee",
 
-    "displayed": "npm run test -- --capabilities.chromeOptions.args="
+    "displayed": "npm run test -- --capabilities.chromeOptions.args=",
 
+    "docker": "docker run --rm -it -u \"$(id -u):$(id -g)\" -v \"$(pwd):/work\" --net=host testx/chrome"
   },
   "testx": {
     "logScript": false,

--- a/package.json
+++ b/package.json
@@ -12,11 +12,21 @@
     "testx-standard-objects": "^0.1.1"
   },
   "scripts": {
-    "test": "docker run --rm -it -u `id -u`:`id -g` -v `pwd`:/work --net=host testx/protractor conf.coffee",
-    "test-local": "protractor conf.coffee"
+    "docker": "docker run --rm -it -u \"$(id -u):$(id -g)\" -v \"$(pwd):/work\" --net=host testx/chrome",
+
+    "pretest": "node_modules/.bin/webdriver-manager update",
+    "test": "protractor conf.coffee",
+
+    "preforeground": "sed -i \"s/\\['--headless', /\\[/\" conf.coffee",
+    "foreground": "npm run test",
+    "postforeground": "sed -i \"s/args: \\[/args: \\['--headless', /\" conf.coffee"
+
   },
   "testx": {
     "logScript": false,
     "actionTimeout": 5000
+  },
+  "devDependencies": {
+    "protractor": "^5.3.2"
   }
 }


### PR DESCRIPTION
Introduction
--------------

This updates the quickstart repo to make the docker test work; it is based on instruction from @greyarch in issue #1.

`conf.coffee`
----------------
Chrome by defaults runs in headless mode.

`package.json`
-------------------
Protractor is added as a dev dependency.

`npm run docker` will run the tests in a headless chrome inside the `testx/chrome` docker image.

`npm run test` will run the tests locally in a headless chrome

`npm run foreground` will run the tests locally in a non-headless chrome.This is achieved by using `sed` to remove the `--headless` argument from `coffee.conf`, which is placed back at the end of the test.


Feedback
------------
I'd like to hear what you think about this.  
At the least I'm still unsure about the names of the new commands (`docker`, `foreground`)

Sidenote
-----------
The testx script (`scripts/my-first-script.testx`) itself is currently broken (probably because google renamed some css locator or something), so I used a known working test to verify that this works.